### PR TITLE
Introduce minimal task manager modules

### DIFF
--- a/event-modeling-codex.cabal
+++ b/event-modeling-codex.cabal
@@ -1,0 +1,13 @@
+cabal-version:       >=1.10
+
+-- This is a simple cabal file for the task manager demo
+name:                event-modeling-codex
+version:             0.1.0.0
+build-type:          Simple
+
+executable event-modeling-codex
+  main-is:             Main.hs
+  hs-source-dirs:      src
+  build-depends:       base >=4.12 && <5
+  default-language:    Haskell2010
+

--- a/src/Domain/Task.hs
+++ b/src/Domain/Task.hs
@@ -1,0 +1,54 @@
+module Domain.Task where
+
+-- | Identifier for tasks
+newtype TaskId = TaskId Int deriving (Show, Eq)
+
+-- | A task has an id, a title, and a completed flag
+data Task = Task
+  { taskId    :: TaskId
+  , title     :: String
+  , completed :: Bool
+  } deriving (Show, Eq)
+
+-- | Commands that can be issued to the system
+data Command
+  = CreateTask TaskId String
+  | CompleteTask TaskId
+  | ListTasks
+  deriving (Show, Eq)
+
+-- | Events produced by handling commands
+data Event
+  = TaskCreated TaskId String
+  | TaskCompleted TaskId
+  deriving (Show, Eq)
+
+-- | The state is just a list of tasks for now
+
+type TaskList = [Task]
+
+-- | Apply an event to the current state
+applyEvent :: TaskList -> Event -> TaskList
+applyEvent tasks (TaskCreated tid ttl) =
+  tasks ++ [Task tid ttl False]
+applyEvent tasks (TaskCompleted tid) =
+  map mark tasks
+  where
+    mark t | taskId t == tid = t { completed = True }
+            | otherwise      = t
+
+-- | Decide which events should be emitted for a given command and state
+
+decide :: TaskList -> Command -> [Event]
+decide tasks (CreateTask tid ttl) =
+  if any ((== tid) . taskId) tasks
+    then [] -- task already exists, no events
+    else [TaskCreated tid ttl]
+
+decide tasks (CompleteTask tid) =
+  if any (
+         \t -> taskId t == tid && not (completed t)) tasks
+    then [TaskCompleted tid]
+    else []
+
+decide _ ListTasks = []

--- a/src/Infrastructure/EventStore.hs
+++ b/src/Infrastructure/EventStore.hs
@@ -1,0 +1,21 @@
+module Infrastructure.EventStore where
+
+import Data.IORef
+
+-- | A very small event store interface
+
+data EventStore m event = EventStore
+  { loadEvents   :: m [event]
+  , appendEvents :: [event] -> m ()
+  }
+
+-- | In-memory implementation using an IORef
+
+inMemoryEventStore :: IO (EventStore IO event)
+
+inMemoryEventStore = do
+  ref <- newIORef []
+  pure EventStore
+    { loadEvents = readIORef ref
+    , appendEvents = \evts -> modifyIORef' ref (++ evts)
+    }

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,0 +1,17 @@
+module Main where
+
+import Domain.Task
+import Infrastructure.EventStore
+
+-- | Simple demo that runs a few commands using the in-memory event store
+
+main :: IO ()
+main = do
+  store <- inMemoryEventStore
+  events0 <- loadEvents store
+  let state0 = foldl applyEvent [] events0
+      newEvents = decide state0 (CreateTask (TaskId 1) "First task")
+      state1 = foldl applyEvent state0 newEvents
+  appendEvents store newEvents
+  putStrLn "Current tasks:" 
+  print state1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-20.26
+packages:
+- .


### PR DESCRIPTION
## Summary
- add domain definitions for `Task`, commands, events and decider logic
- implement a simple in-memory event store
- provide a small `Main` demo using the store
- add basic cabal and stack configuration

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_b_6840ae7f716c833087e090e002cb9cd9