### PR TITLE
Add Haskell installation script

### DIFF
--- a/scripts/install-haskell.sh
+++ b/scripts/install-haskell.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Install ghcup if it isn't present
+if ! command -v ghcup >/dev/null 2>&1; then
+    echo "Installing ghcup..."
+    curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org \
+      | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+fi
+
+# Ensure the ghcup binaries are on PATH
+export PATH="$HOME/.ghcup/bin:$PATH"
+
+# Install latest GHC, Cabal, and Stack
+ghcup install ghc latest
+ghcup install cabal latest
+ghcup install stack latest
+
+# Set the installed versions as default
+ghcup set ghc latest
+ghcup set cabal latest
+
+# Add ghcup to bashrc if not already
+if ! grep -q 'ghcup/bin' "$HOME/.bashrc" 2>/dev/null; then
+  echo 'export PATH="$HOME/.ghcup/bin:$PATH"' >> "$HOME/.bashrc"
+fi
+
+echo "Haskell toolchain installed. Open a new shell or source ~/.bashrc to use ghc, cabal, and stack."


### PR DESCRIPTION
## Summary
- add `install-haskell.sh` for ghcup-based toolchain installation

## Testing
- `./scripts/install-haskell.sh` *(fails: ghcup not installed)*
- `./scripts/test.sh` *(fails: Haskell toolchain not available)*

------
https://chatgpt.com/codex/tasks/task_b_6842c1ed555483308d58c5c197a6291b